### PR TITLE
Support both Once and ColumnMap callback names

### DIFF
--- a/html/Callbacks/RT-Extension-QuickDelete/Elements/RT__Ticket/ColumnMap/Once
+++ b/html/Callbacks/RT-Extension-QuickDelete/Elements/RT__Ticket/ColumnMap/Once
@@ -1,0 +1,1 @@
+ColumnMap


### PR DESCRIPTION
Apparently the RT__Ticket/ColumnMap callback named ColumnMap was removed in
4.2. Add a symlink that makes the QuickDelete column work again in newer
versions of RT.
